### PR TITLE
#19 Support both editor aliases in IsConverter for compatibility

### DIFF
--- a/MetaMomentum/Constants.cs
+++ b/MetaMomentum/Constants.cs
@@ -1,0 +1,7 @@
+﻿
+
+namespace MetaMomentum {
+	public static class Constants {
+		public const string EditorAlias = "DM.MetaMomentum";
+	}
+}

--- a/MetaMomentum/MetaMomentum.csproj
+++ b/MetaMomentum/MetaMomentum.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>17.0.0</Version>
+		<Version>17.0.1</Version>
 		<PackageId>MetaMomentum</PackageId>
 		<Title>MetaMomentum</Title>
 		<Description>Creates a Meta DataType for Umbraco to manage Search Engine results, Open Graph and Twitter Cards with a friendly preview</Description>
@@ -25,7 +25,10 @@
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageReadmeFile>readme.nuget.md</PackageReadmeFile>
 		<Nullable>disable</Nullable>
-		<PackageReleaseNotes>- Upgraded to support Umbraco 17</PackageReleaseNotes>
+		<PackageReleaseNotes>
+			- Upgraded to support Umbraco 17
+			- Fix Backwards compatibility for upgrades of pre umbraco 15 versions
+		</PackageReleaseNotes>
 
 	</PropertyGroup>
 
@@ -71,7 +74,6 @@
 		<EmbeddedResource Remove="Controllers\**" />
 		<None Remove="Composers\**" />
 		<None Remove="Controllers\**" />
-		<Compile Remove="Constants.cs" />
 
 		<!-- However make the Umbraco-package.json included for dotnet pack or nuget package and visible to the solution -->
 		<None Include="Client\public\umbraco-package.json" Pack="false" />

--- a/MetaMomentum/MetaMomentum.csproj
+++ b/MetaMomentum/MetaMomentum.csproj
@@ -27,7 +27,7 @@
 		<Nullable>disable</Nullable>
 		<PackageReleaseNotes>
 			- Upgraded to support Umbraco 17
-			- Fix Backwards compatibility for upgrades of pre umbraco 15 versions
+			- Fixed backwards compatibility for upgrades from pre-Umbraco 15 versions
 		</PackageReleaseNotes>
 
 	</PropertyGroup>

--- a/MetaMomentum/MetaMomentumConstants.cs
+++ b/MetaMomentum/MetaMomentumConstants.cs
@@ -1,7 +1,7 @@
 ﻿
 
 namespace MetaMomentum {
-	public static class Constants {
+	public static class MetaMomentumConstants {
 		public const string EditorAlias = "DM.MetaMomentum";
 	}
 }

--- a/MetaMomentum/PropertyEditors/MetaMomentumValueConverter.cs
+++ b/MetaMomentum/PropertyEditors/MetaMomentumValueConverter.cs
@@ -145,7 +145,7 @@ namespace MetaMomentum.PropertyEditors {
 
 		public bool IsConverter(IPublishedPropertyType propertyType) {
 			return propertyType.EditorUiAlias.Equals(MetaMomentum.Constants.EditorAlias) || 
-				propertyType.EditorAlias.Equals(MetaMomentum.Constants.EditorAlias); //Editor Alias should be Umbraco.Plain.Json, however on upgrade from pre Umb 15, the old editor alias may still be in place, so we need to check both.
+				propertyType.EditorAlias.Equals(MetaMomentum.Constants.EditorAlias); //Editor Alias should be Umbraco.Plain.Json, however on upgrade from pre Umb 15, the old editor alias may still be in place and EditorUiAlias may be empty, so we need to check both.
 		}
 
 		public bool? IsValue(object? value, PropertyValueLevel level) {

--- a/MetaMomentum/PropertyEditors/MetaMomentumValueConverter.cs
+++ b/MetaMomentum/PropertyEditors/MetaMomentumValueConverter.cs
@@ -141,8 +141,11 @@ namespace MetaMomentum.PropertyEditors {
 			return typeof(MetaValues);
 		}
 
+		
+
 		public bool IsConverter(IPublishedPropertyType propertyType) {
-			return propertyType.EditorUiAlias.Equals("DM.MetaMomentum");
+			return propertyType.EditorUiAlias.Equals(MetaMomentum.Constants.EditorAlias) || 
+				propertyType.EditorAlias.Equals(MetaMomentum.Constants.EditorAlias); //Editor Alias should be Umbraco.Plain.Json, however on upgrade from pre Umb 15, the old editor alias may still be in place, so we need to check both.
 		}
 
 		public bool? IsValue(object? value, PropertyValueLevel level) {

--- a/MetaMomentum/PropertyEditors/MetaMomentumValueConverter.cs
+++ b/MetaMomentum/PropertyEditors/MetaMomentumValueConverter.cs
@@ -141,11 +141,9 @@ namespace MetaMomentum.PropertyEditors {
 			return typeof(MetaValues);
 		}
 
-		
-
 		public bool IsConverter(IPublishedPropertyType propertyType) {
-			return propertyType.EditorUiAlias.Equals(MetaMomentum.Constants.EditorAlias) || 
-				propertyType.EditorAlias.Equals(MetaMomentum.Constants.EditorAlias); //Editor Alias should be Umbraco.Plain.Json, however on upgrade from pre Umb 15, the old editor alias may still be in place, so we need to check both.
+			return propertyType.EditorUiAlias.Equals(MetaMomentumConstants.EditorAlias) || 
+				propertyType.EditorAlias.Equals(MetaMomentumConstants.EditorAlias); //Editor Alias should be Umbraco.Plain.Json, however on upgrade from pre Umb 15, the old editor alias may still be in place and EditorUiAlias may be empty, so we need to check both.
 		}
 
 		public bool? IsValue(object? value, PropertyValueLevel level) {


### PR DESCRIPTION
Updated IsConverter to check both EditorUiAlias and EditorAlias for "DM.MetaMomentum" to ensure compatibility with properties from pre-Umbraco 15 upgrades. Added a comment explaining the dual check.